### PR TITLE
Fix clippy/rust warnings and glow/wgpu compilation usability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ canvas = ["iced_wgpu/canvas"]
 # Enables using system fonts.
 default_system_font = ["iced_wgpu/default_system_font"]
 
-# Enables the `wgpu` rendering backend
+# Enables the `glow` rendering backend
 glow = ["iced_glow", "raw-gl-context"]
 # Enables the `Canvas` widget
 glow_canvas = ["iced_glow/canvas"]

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,7 +1,4 @@
-use crate::{
-    Color, Command, Compositor, Element, Executor, Renderer, Subscription,
-    WindowSubs,
-};
+use crate::{Color, Command, Element, Executor, Subscription, WindowSubs};
 
 use baseview::WindowScalePolicy;
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -198,6 +198,7 @@ pub trait Application: Sized + 'static {
 
     /// Returns the renderer settings
     #[cfg(feature = "glow")]
+    #[cfg(not(feature = "wgpu"))]
     fn renderer_settings(
     ) -> (raw_gl_context::GlConfig, iced_glow::settings::Settings) {
         (

--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -196,7 +196,7 @@ impl<A: Application + Send> State<A> {
                 let matches = match &self.scale_policy {
                     WindowScalePolicy::SystemScaleFactor => false,
                     WindowScalePolicy::ScaleFactor(scale) => {
-                        *scale == *new_scale
+                        (*scale - *new_scale).abs() < f64::EPSILON
                     }
                 };
 

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -136,15 +136,13 @@ pub fn baseview_to_iced_events(
                         ));
                     }
                 }
-            } else {
-                if let Some(key_code) = opt_key_code {
-                    iced_events.push(IcedEvent::Keyboard(
-                        IcedKeyEvent::KeyReleased {
-                            key_code,
-                            modifiers: *modifiers,
-                        },
-                    ));
-                }
+            } else if let Some(key_code) = opt_key_code {
+                iced_events.push(IcedEvent::Keyboard(
+                    IcedKeyEvent::KeyReleased {
+                        key_code,
+                        modifiers: *modifiers,
+                    },
+                ));
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,13 @@ type Compositor = iced_wgpu::window::Compositor;
 pub use iced_wgpu as renderer;
 
 #[cfg(feature = "glow")]
+#[cfg(not(feature = "wgpu"))]
 type Renderer = iced_glow::Renderer;
 #[cfg(feature = "glow")]
+#[cfg(not(feature = "wgpu"))]
 type Compositor = iced_glow::window::Compositor;
 #[cfg(feature = "glow")]
+#[cfg(not(feature = "wgpu"))]
 pub use iced_glow as renderer;
 
 #[doc(no_inline)]

--- a/src/window.rs
+++ b/src/window.rs
@@ -398,6 +398,7 @@ impl<A: Application + 'static + Send> WindowHandler for IcedWindow<A> {
 // This may appear to be asynchronous, but it is actually a blocking future on the same thread.
 // This is a necessary workaround for the issue described here:
 // https://github.com/hecrj/iced/pull/597
+#[allow(clippy::too_many_arguments)]
 async fn run_instance<A, E>(
     mut application: A,
     mut compositor: Compositor,
@@ -496,7 +497,7 @@ async fn run_instance<A, E>(
                 let statuses = user_interface.update(
                     &events,
                     state.cursor_position(),
-                    &mut renderer,
+                    &renderer,
                     &mut clipboard, // TODO: clipboard
                     &mut messages,
                 );
@@ -540,7 +541,7 @@ async fn run_instance<A, E>(
                     let statuses = user_interface.update(
                         &events,
                         state.cursor_position(),
-                        &mut renderer,
+                        &renderer,
                         &mut clipboard, // TODO: clipboard
                         &mut messages,
                     );
@@ -726,12 +727,11 @@ pub fn requests_exit(event: &baseview::Event) -> bool {
         baseview::Event::Window(baseview::WindowEvent::WillClose) => true,
         #[cfg(target_os = "macos")]
         baseview::Event::Keyboard(event) => {
-            if event.code == keyboard_types::Code::KeyQ {
-                if event.modifiers == keyboard_types::Modifiers::META {
-                    if event.state == keyboard_types::KeyState::Down {
-                        return true;
-                    }
-                }
+            if event.code == keyboard_types::Code::KeyQ
+                && event.modifiers == keyboard_types::Modifiers::META
+                && event.state == keyboard_types::KeyState::Down
+            {
+                return true;
             }
 
             false

--- a/src/window.rs
+++ b/src/window.rs
@@ -116,6 +116,7 @@ impl<A: Application + 'static + Send> IcedWindow<A> {
         use iced_graphics::window::Compositor as IGCompositor;
 
         #[cfg(feature = "glow")]
+        #[cfg(not(feature = "wgpu"))]
         use iced_graphics::window::GLCompositor as IGCompositor;
 
         let mut debug = Debug::new();
@@ -163,6 +164,7 @@ impl<A: Application + 'static + Send> IcedWindow<A> {
             <Compositor as IGCompositor>::new(renderer_settings).unwrap();
 
         #[cfg(feature = "glow")]
+        #[cfg(not(feature = "wgpu"))]
         let (context, compositor, renderer) = {
             let context =
                 raw_gl_context::GlContext::create(window, renderer_settings.0)
@@ -204,6 +206,7 @@ impl<A: Application + 'static + Send> IcedWindow<A> {
         ));
 
         #[cfg(feature = "glow")]
+        #[cfg(not(feature = "wgpu"))]
         let instance = Box::pin(run_instance(
             application,
             compositor,
@@ -409,6 +412,7 @@ async fn run_instance<A, E>(
 
     #[rustfmt::skip]
     #[cfg(feature = "glow")]
+    #[cfg(not(feature = "wgpu"))]
     gl_context: raw_gl_context::GlContext,
 
     mut state: State<A>,
@@ -422,6 +426,7 @@ async fn run_instance<A, E>(
     use iced_graphics::window::Compositor as IGCompositor;
 
     #[cfg(feature = "glow")]
+    #[cfg(not(feature = "wgpu"))]
     use iced_graphics::window::GLCompositor as IGCompositor;
 
     //let clipboard = Clipboard::new(window);  // TODO: clipboard
@@ -598,6 +603,7 @@ async fn run_instance<A, E>(
                     }
 
                     #[cfg(feature = "glow")]
+                    #[cfg(not(feature = "wgpu"))]
                     {
                         gl_context.make_current();
                         compositor.resize_viewport(physical_size);
@@ -636,6 +642,7 @@ async fn run_instance<A, E>(
                     );
 
                     #[cfg(feature = "glow")]
+                    #[cfg(not(feature = "wgpu"))]
                     let new_mouse_interaction = {
                         gl_context.make_current();
 


### PR DESCRIPTION
* Fix clippy warnings
* Fix typo in cargo manifest re wgpu/glow feature
* If accidentally both glow / wgpu features are enabled, give precedence to wgpu rather than failing to compile