### PR TITLE
Fix tokio executor in iced-baseview

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -38,7 +38,7 @@ mod platform {
         }
 
         fn enter<R>(&self, f: impl FnOnce() -> R) -> R {
-            self.0.enter(f)
+            super::Executor::enter(&self.0, f)
         }
     }
 }


### PR DESCRIPTION
Fixes compilation with `tokio` feature.