### PR TITLE
Fix iced-baseview compilation with latest iced master

### DIFF
--- a/src/application/state.rs
+++ b/src/application/state.rs
@@ -128,12 +128,23 @@ impl<A: Application + Send> State<A> {
             baseview::Event::Keyboard(event) => {
                 use keyboard_types::Modifiers as KeyModifiers;
 
-                self.modifiers = keyboard::Modifiers {
-                    shift: event.modifiers.contains(KeyModifiers::SHIFT),
-                    control: event.modifiers.contains(KeyModifiers::CONTROL),
-                    alt: event.modifiers.contains(KeyModifiers::ALT),
-                    logo: event.modifiers.contains(KeyModifiers::META),
-                };
+                self.modifiers = keyboard::Modifiers::empty();
+                self.modifiers.set(
+                    keyboard::Modifiers::SHIFT,
+                    event.modifiers.contains(KeyModifiers::SHIFT),
+                );
+                self.modifiers.set(
+                    keyboard::Modifiers::CTRL,
+                    event.modifiers.contains(KeyModifiers::CONTROL),
+                );
+                self.modifiers.set(
+                    keyboard::Modifiers::ALT,
+                    event.modifiers.contains(KeyModifiers::ALT),
+                );
+                self.modifiers.set(
+                    keyboard::Modifiers::LOGO,
+                    event.modifiers.contains(KeyModifiers::META),
+                );
             }
             #[cfg(feature = "debug")]
             WindowEvent::KeyboardInput {

--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -78,35 +78,35 @@ pub fn baseview_to_iced_events(
             // is fixed in baseview.
             let is_modifier = match event.code {
                 Code::AltLeft => {
-                    modifiers.alt = is_down;
+                    modifiers.set(IcedModifiers::ALT, is_down);
                     true
                 }
                 Code::AltRight => {
-                    modifiers.alt = is_down;
+                    modifiers.set(IcedModifiers::ALT, is_down);
                     true
                 }
                 Code::ControlLeft => {
-                    modifiers.control = is_down;
+                    modifiers.set(IcedModifiers::CTRL, is_down);
                     true
                 }
                 Code::ControlRight => {
-                    modifiers.control = is_down;
+                    modifiers.set(IcedModifiers::CTRL, is_down);
                     true
                 }
                 Code::ShiftLeft => {
-                    modifiers.shift = is_down;
+                    modifiers.set(IcedModifiers::SHIFT, is_down);
                     true
                 }
                 Code::ShiftRight => {
-                    modifiers.shift = is_down;
+                    modifiers.set(IcedModifiers::SHIFT, is_down);
                     true
                 }
                 Code::MetaLeft => {
-                    modifiers.logo = is_down;
+                    modifiers.set(IcedModifiers::LOGO, is_down);
                     true
                 }
                 Code::MetaRight => {
-                    modifiers.logo = is_down;
+                    modifiers.set(IcedModifiers::LOGO, is_down);
                     true
                 }
                 _ => false,
@@ -156,10 +156,10 @@ pub fn baseview_to_iced_events(
                 }));
             }
             baseview::WindowEvent::Unfocused => {
-                modifiers.alt = false;
-                modifiers.shift = false;
-                modifiers.control = false;
-                modifiers.logo = false;
+                modifiers.set(IcedModifiers::ALT, false);
+                modifiers.set(IcedModifiers::SHIFT, false);
+                modifiers.set(IcedModifiers::CTRL, false);
+                modifiers.set(IcedModifiers::LOGO, false);
             }
             _ => {}
         },

--- a/src/window.rs
+++ b/src/window.rs
@@ -457,12 +457,7 @@ async fn run_instance<A, E>(
     let mut redraw_requested = true;
     let mut did_process_event = false;
 
-    let mut modifiers = iced_core::keyboard::Modifiers {
-        shift: false,
-        control: false,
-        alt: false,
-        logo: false,
-    };
+    let mut modifiers = iced_core::keyboard::Modifiers::empty();
 
     debug.startup_finished();
 


### PR DESCRIPTION
Fixes compilation with the latest `iced` master after the `menu` addition.

You may want to wait as this should not work with `0.3`.