### PR TITLE
Actually redraw when always_redraw is enabled

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -627,6 +627,7 @@ async fn run_instance<A, E>(
                 if !did_process_event
                     && events.is_empty()
                     && messages.is_empty()
+                    && !settings.always_redraw
                 {
                     continue;
                 }
@@ -655,7 +656,7 @@ async fn run_instance<A, E>(
                 }
 
                 // The user interface update may have pushed a new message onto the stack
-                needs_update |= !messages.is_empty();
+                needs_update |= !messages.is_empty() || settings.always_redraw;
                 if needs_update {
                     needs_update = false;
 


### PR DESCRIPTION
#26 added this option to fix missing redraws causing blank windows, but it did not actually always trigger a redraw. That meant that while it did fix the problem it aimed to fix, it means you still couldn't do animations without ugly hacks involving timers on the root Application. This change always redraws the application on every frame when the `always_redraw` setting is enabled. If you want I can also turn this into an enum so you can choose between having it either only redraw the already composed frame or having a full redraw every frame.